### PR TITLE
Sorted Results For Nested Hash Fix

### DIFF
--- a/Lesson6/activity/solution/models/voting_machine.rb
+++ b/Lesson6/activity/solution/models/voting_machine.rb
@@ -25,7 +25,7 @@ class VotingMachine
   end
 
   def sorted_results
-    results.sort_by(&:last).reverse
+    results.map{|k, v| {k => v.sort_by(&:last).reverse}}
   end
 
   private

--- a/Lesson6/activity/solution/tests/test_voting_machine.rb
+++ b/Lesson6/activity/solution/tests/test_voting_machine.rb
@@ -29,6 +29,7 @@ class TestVotingMachine < Minitest::Test
     machine.record_vote(category2, "Jackie", "Sam")
 
     assert_equal machine.results.class, Hash
+    assert_equal machine.sorted_results.class, Array
     assert_equal machine.results.keys, [category1, category2]
 
     assert_raises VotingMachine::InvalidCategory do


### PR DESCRIPTION
Adding multiple categories and calling `voting_machine.sorted_results` throws an exception
```ArgumentError: comparison of Hash with Hash failed```
Looks like it's to do with the sorted results method not being updated to handle categories added from the previous chapter.